### PR TITLE
install_symlink: Make symlink target configurable

### DIFF
--- a/etc/install_symlink.go
+++ b/etc/install_symlink.go
@@ -18,6 +18,8 @@ import (
 	"android/soong/android"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/blueprint/proptools"
 )
 
 func init() {
@@ -52,7 +54,7 @@ type InstallSymlinkProperties struct {
 	// properties.
 	Installed_location string
 	// The target of the symlink, aka where the symlink points.
-	Symlink_target string
+	Symlink_target proptools.Configurable[string]
 }
 
 type InstallSymlink struct {
@@ -64,7 +66,8 @@ type InstallSymlink struct {
 }
 
 func (m *InstallSymlink) GenerateAndroidBuildActions(ctx android.ModuleContext) {
-	if filepath.Clean(m.properties.Symlink_target) != m.properties.Symlink_target {
+	symlink_target := m.properties.Symlink_target.GetOrDefault(ctx, "")
+	if filepath.Clean(symlink_target) != symlink_target {
 		ctx.PropertyErrorf("symlink_target", "Should be a clean filepath")
 		return
 	}
@@ -83,7 +86,7 @@ func (m *InstallSymlink) GenerateAndroidBuildActions(ctx android.ModuleContext) 
 
 	name := filepath.Base(m.properties.Installed_location)
 	installDir := android.PathForModuleInstall(ctx, filepath.Dir(m.properties.Installed_location))
-	m.installedPath = ctx.InstallAbsoluteSymlink(installDir, name, m.properties.Symlink_target)
+	m.installedPath = ctx.InstallAbsoluteSymlink(installDir, name, symlink_target)
 }
 
 func (m *InstallSymlink) AndroidMkEntries() []android.AndroidMkEntries {


### PR DESCRIPTION
Can be useful on trees supporting multiple QCOM families where firmware may have different mount points and there's a generic installed symlink pointing to the correct path.

Test: m
Change-Id: Id2c5c62e8e6f7cc8326ba213ddaacb5e4e2c13e6